### PR TITLE
INT-734 - CreatedBy property not getting ingested when module completed

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@jupiterone/jupiter-managed-integration-sdk": "^33.7.5",
     "@types/uuid": "^3.4.4",
     "lodash.camelcase": "^4.3.0",
+    "lodash.groupby": "^4.6.0",
+    "lodash.maxby": "^4.6.0",
     "request-promise-native": "^1.0.7"
   },
   "devDependencies": {
@@ -45,6 +47,8 @@
     "@types/gremlin": "^3.4.2",
     "@types/jest": "^24.0.0",
     "@types/lodash.camelcase": "^4.3.6",
+    "@types/lodash.groupby": "^4.6.6",
+    "@types/lodash.maxby": "^4.6.6",
     "@types/node": "^12.0.0",
     "@types/request-promise-native": "^1.0.16",
     "bunyan": "^1.8.12",

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -2,6 +2,7 @@ import {
   EntityFromIntegration,
   RelationshipFromIntegration,
 } from "@jupiterone/jupiter-managed-integration-sdk";
+import groupBy from "lodash.groupby";
 
 import {
   Account,
@@ -39,6 +40,8 @@ import {
   USER_GROUP_RELATIONSHIP_TYPE,
   UserEntity,
 } from "./types";
+import { filterDuplicateModules } from "./util/filterDuplicateModules";
+import { findMostRelevantEnrollment } from "./util/findMostRelevantEnrollment";
 import getTime from "./util/getTime";
 import toCamelCase from "./util/toCamelCase";
 
@@ -97,16 +100,18 @@ export function createTrainingEntities(
   data: TrainingCampaign[],
 ): TrainingCollection {
   const trainingEntities: TrainingEntity[] = [];
-  const trainingModules: TrainingModuleEntity[] = [];
+  let trainingModules: TrainingModuleEntity[] = [];
 
   data.forEach(d => {
     trainingEntities.push(createTrainingEntity(d));
-    trainingModules.push(...createTrainingModuleEntities(d.content, d.name));
+    trainingModules = trainingModules.concat(
+      createTrainingModuleEntities(d.content),
+    );
   });
 
   return {
     trainingEntities,
-    trainingModules,
+    trainingModules: filterDuplicateModules(trainingModules),
   };
 }
 
@@ -148,16 +153,16 @@ export function createTrainingEntity(data: TrainingCampaign): TrainingEntity {
 
 export function createTrainingModuleEntities(
   data: TrainingContent[],
-  campaign: string,
 ): TrainingModuleEntity[] {
-  return data.map(d => ({
-    ...(toCamelCase(d) as any),
-    _class: TRAINING_MODULE_ENTITY_CLASS,
-    _key: createTrainingModuleKey(d),
-    _type: TRAINING_MODULE_ENTITY_TYPE,
-    displayName: d.name,
-    campaign,
-  }));
+  return data
+    .filter(d => !d.retired)
+    .map(d => ({
+      ...(toCamelCase(d) as any),
+      _class: TRAINING_MODULE_ENTITY_CLASS,
+      _key: createTrainingModuleKey(d),
+      _type: TRAINING_MODULE_ENTITY_TYPE,
+      displayName: d.name,
+    }));
 }
 
 function createTrainingModuleKey(d: Partial<TrainingContent>) {
@@ -321,7 +326,14 @@ export function createTrainingEnrollmentRelationships(
   }
 
   const relationships: TrainingEnrollmentRelationship[] = [];
-  for (const e of enrollments) {
+  const enrollmentsByUserIdAndModule = groupBy(
+    enrollments,
+    e => `${e.user.id}|${e.module_name}`,
+  );
+  for (const userIdModulePair of Object.keys(enrollmentsByUserIdAndModule)) {
+    const e = findMostRelevantEnrollment(
+      enrollmentsByUserIdAndModule[userIdModulePair],
+    );
     const m = modulesByName[e.module_name];
     const u = usersById[e.user.id];
     if (m && u) {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -154,15 +154,13 @@ export function createTrainingEntity(data: TrainingCampaign): TrainingEntity {
 export function createTrainingModuleEntities(
   data: TrainingContent[],
 ): TrainingModuleEntity[] {
-  return data
-    .filter(d => !d.retired)
-    .map(d => ({
-      ...(toCamelCase(d) as any),
-      _class: TRAINING_MODULE_ENTITY_CLASS,
-      _key: createTrainingModuleKey(d),
-      _type: TRAINING_MODULE_ENTITY_TYPE,
-      displayName: d.name,
-    }));
+  return data.map(d => ({
+    ...(toCamelCase(d) as any),
+    _class: TRAINING_MODULE_ENTITY_CLASS,
+    _key: createTrainingModuleKey(d),
+    _type: TRAINING_MODULE_ENTITY_TYPE,
+    displayName: d.name,
+  }));
 }
 
 function createTrainingModuleKey(d: Partial<TrainingContent>) {

--- a/src/test-data/training-campaigns.json
+++ b/src/test-data/training-campaigns.json
@@ -49,6 +49,55 @@
     "allow_multiple_enrollments": true
   },
   {
+    "campaign_id": 3318,
+    "name": "Remedial Campaign - Northeast",
+    "groups": [
+      {
+        "group_id": 16343,
+        "name": "Northwest Clickers"
+      }
+    ],
+    "status": "Completed",
+    "modules": [
+      {
+        "store_purchase_id": 19,
+        "content_type": "Store Purchase",
+        "name": "2018 Kevin Mitnick Security Awareness Training - 15 min",
+        "description": "This 15-minute module is an advanced, condensed version of the full 45-minute training, often...",
+        "type": "Training Module",
+        "duration": 15,
+        "retired": false,
+        "retirement_date": null,
+        "publish_date": "2018-02-03T02:20:00.000Z",
+        "publisher": "KnowBe4",
+        "purchase_date": "2017-06-18T00:00:00.000Z",
+        "policy_url": "https://www.yourcompany.com/phishingawarenesspolicy.pdf"
+      }
+    ],
+    "content": [
+      {
+        "store_purchase_id": 19,
+        "content_type": "Store Purchase",
+        "name": "2018 Kevin Mitnick Security Awareness Training - 15 min",
+        "description": "This 15-minute module is an advanced, condensed version of the full 45-minute training, often...",
+        "type": "Training Module",
+        "duration": 15,
+        "retired": false,
+        "retirement_date": null,
+        "publish_date": "2018-02-03T02:20:00.000Z",
+        "publisher": "KnowBe4",
+        "purchase_date": "2017-06-18T00:00:00.000Z",
+        "policy_url": "https://www.yourcompany.com/phishingawarenesspolicy.pdf"
+      }
+    ],
+    "duration_type": "Relative Duration",
+    "start_date": "2018-05-04T13:00:00.000Z",
+    "end_date": null,
+    "relative_duration": "1 week",
+    "auto_enroll": true,
+    "allow_multiple_enrollments": true
+  },
+  {
     "campaign_id": 3261,
     "name": "Annual Training",
     "groups": [

--- a/src/test-data/training-enrollments.json
+++ b/src/test-data/training-enrollments.json
@@ -45,12 +45,48 @@
       "last_name": "Fisher",
       "email": "sfisher@kb4-demo.com"
     },
+    "campaign_name": "New Employee Policies 2",
+    "enrollment_date": "2018-06-18T19:00:14.000Z",
+    "start_date": null,
+    "completion_date": null,
+    "status": "Not Started",
+    "time_spent": 0,
+    "policy_acknowledged": false
+  },
+  {
+    "enrollment_id": 2525523,
+    "content_type": "Uploaded Policy",
+    "module_name": "Acceptable Use Policy",
+    "user": {
+      "id": 796702,
+      "first_name": "Sarah",
+      "last_name": "Fisher",
+      "email": "sfisher@kb4-demo.com"
+    },
     "campaign_name": "New Employee Policies",
     "enrollment_date": "2018-06-18T19:00:14.000Z",
     "start_date": "2018-06-18T19:49:00.000Z",
     "completion_date": "2018-06-18T21:49:00.000Z",
     "status": "Passed",
     "time_spent": 2340,
+    "policy_acknowledged": false
+  },
+  {
+    "enrollment_id": 2525523,
+    "content_type": "Uploaded Policy",
+    "module_name": "Acceptable Use Policy",
+    "user": {
+      "id": 796702,
+      "first_name": "Sarah",
+      "last_name": "Fisher",
+      "email": "sfisher@kb4-demo.com"
+    },
+    "campaign_name": "New Employee Policies 2",
+    "enrollment_date": "2018-06-18T19:00:14.000Z",
+    "start_date": null,
+    "completion_date": null,
+    "status": "Not Started",
+    "time_spent": 0,
     "policy_acknowledged": false
   }
 ]

--- a/src/test-data/training-entities.json
+++ b/src/test-data/training-entities.json
@@ -18,6 +18,24 @@
     "allowMultipleEnrollments": true
   },
   {
+    "_key": "knowbe4:training:campaign:3318",
+    "_type": "training_campaign",
+    "_class": "Training",
+    "displayName": "Remedial Campaign - Northeast",
+    "id": 3318,
+    "campaignId": 3318,
+    "name": "Remedial Campaign - Northeast",
+    "groups": [16343],
+    "status": "Completed",
+    "modules": [19],
+    "content": [],
+    "durationType": "Relative Duration",
+    "startDate": 1525438800000,
+    "relativeDuration": "1 week",
+    "autoEnroll": true,
+    "allowMultipleEnrollments": true
+  },
+  {
     "_key": "knowbe4:training:campaign:3261",
     "_type": "training_campaign",
     "_class": "Training",

--- a/src/test-data/training-module-entities.json
+++ b/src/test-data/training-module-entities.json
@@ -14,8 +14,7 @@
     "publishDate": 1517624400000,
     "publisher": "KnowBe4",
     "purchaseDate": 1497744000000,
-    "policyUrl": "https://www.yourcompany.com/phishingawarenesspolicy.pdf",
-    "campaign": "Remedial Campaign - Northwest"
+    "policyUrl": "https://www.yourcompany.com/phishingawarenesspolicy.pdf"
   },
   {
     "_key": "knowbe4:training:purchase:9",
@@ -32,8 +31,7 @@
     "publishDate": 1517624400000,
     "publisher": "KnowBe4",
     "purchaseDate": 1529280000000,
-    "policyUrl": "https://www.yourcompany.com/employees/acceptableusepolicy.html",
-    "campaign": "Annual Training"
+    "policyUrl": "https://www.yourcompany.com/employees/acceptableusepolicy.html"
   },
   {
     "_key": "knowbe4:training:purchase:106",
@@ -50,8 +48,7 @@
     "publishDate": 1483669200000,
     "publisher": "Security Awareness Company",
     "purchaseDate": 1483938000000,
-    "policyUrl": "https://www.yourcompany.com/employees/HIPAA-policy.html",
-    "campaign": "Annual Training"
+    "policyUrl": "https://www.yourcompany.com/employees/HIPAA-policy.html"
   },
   {
     "_key": "knowbe4:training:policy:150",
@@ -63,8 +60,7 @@
     "name": "Security Awareness Policy",
     "minimumTime": 3,
     "defaultLanguage": "en-us",
-    "published": true,
-    "campaign": "Annual Training"
+    "published": true
   },
   {
     "_key": "knowbe4:training:module:random",
@@ -73,7 +69,6 @@
     "displayName": "Random",
     "contentType": "Unknown",
     "contentId": 1,
-    "name": "Random",
-    "campaign": "Annual Training"
+    "name": "Random"
   }
 ]

--- a/src/util/filterDuplicateModules.test.ts
+++ b/src/util/filterDuplicateModules.test.ts
@@ -1,0 +1,30 @@
+import { filterDuplicateModules } from "./filterDuplicateModules";
+
+function createTrainingModule() {
+  return {
+    _key: "knowbe4:training:purchase:19",
+    _type: "training_module",
+    _class: ["Training", "Module"],
+    displayName: "2018 Kevin Mitnick Security Awareness Training - 15 min",
+    storePurchaseId: 19,
+    contentType: "Store Purchase",
+    name: "2018 Kevin Mitnick Security Awareness Training - 15 min",
+    description:
+      "This 15-minute module is an advanced, condensed version of the full 45-minute training, often...",
+    type: "Training Module",
+    duration: 15,
+    retired: false,
+    publishDate: 1517624400000,
+    publisher: "KnowBe4",
+    purchaseDate: 1497744000000,
+    policyUrl: "https://www.yourcompany.com/phishingawarenesspolicy.pdf",
+  };
+}
+
+describe("filterDuplicateModules", () => {
+  it("should filter out duplicate training modules", () => {
+    expect(
+      filterDuplicateModules(new Array(10).fill(createTrainingModule())),
+    ).toEqual([createTrainingModule()]);
+  });
+});

--- a/src/util/filterDuplicateModules.ts
+++ b/src/util/filterDuplicateModules.ts
@@ -1,0 +1,17 @@
+import { TrainingModuleEntity } from "../types";
+
+/**
+ * There can be multiple instances of the same training module in several
+ * different KnowBe4 training compaigns. Because we do not want to put
+ * campaign information in the training module key (as that is what
+ * relationships are for), we need to de-duplicate the training modules
+ * prior to sending them to the persister in order to avoid errors.
+ */
+export function filterDuplicateModules(
+  modules: TrainingModuleEntity[],
+): TrainingModuleEntity[] {
+  return modules.filter(
+    (moduleVal, moduleIndex, iteratee) =>
+      !iteratee.find((v, i) => i > moduleIndex && v._key === moduleVal._key),
+  );
+}

--- a/src/util/findMostRelevantEnrollment.test.ts
+++ b/src/util/findMostRelevantEnrollment.test.ts
@@ -1,0 +1,113 @@
+import { TrainingEnrollment } from "../ProviderClient";
+import { findMostRelevantEnrollment } from "./findMostRelevantEnrollment";
+
+const enrollmentId = 12345;
+const userId = 67890;
+const baseDate = "2000-01-01T01:00:00.000Z";
+
+function createTestEnrollment(
+  overrides: Partial<TrainingEnrollment> = {},
+): TrainingEnrollment {
+  return {
+    enrollment_id: enrollmentId,
+    content_type: "Uploaded Policy",
+    module_name: "Data Protection Policy",
+    user: {
+      id: userId,
+      first_name: "Bob",
+      last_name: "Bobkins",
+      email: "bbobkins@kb4-demo.com",
+    },
+    campaign_name: "Compliance Policy Agreement",
+    enrollment_date: baseDate,
+    start_date: null,
+    completion_date: null,
+    status: "Unknown",
+    time_spent: 0,
+    policy_acknowledged: false,
+    ...overrides,
+  };
+}
+
+const completedEnrollment = createTestEnrollment({
+  start_date: baseDate,
+  completion_date: baseDate,
+  status: "Passed",
+});
+
+const inProgressEnrollment = createTestEnrollment({
+  start_date: baseDate,
+  completion_date: null,
+  status: "Passed",
+});
+
+const notStartedEnrollment = createTestEnrollment({
+  start_date: null,
+  completion_date: null,
+  status: "Not Started",
+});
+
+const malformedEnrollment = createTestEnrollment({
+  enrollment_date: undefined,
+  start_date: null,
+  completion_date: null,
+  status: "Error",
+});
+
+describe("findMostRelevantEnrollment", () => {
+  it("should select the enrollment with the most recent completed date", () => {
+    const newestCompletedEnrollment = createTestEnrollment({
+      start_date: baseDate,
+      completion_date: new Date(
+        new Date(baseDate).getTime() + 100000,
+      ).toISOString(),
+      status: "Passed",
+    });
+    expect(
+      findMostRelevantEnrollment([
+        malformedEnrollment,
+        newestCompletedEnrollment,
+        completedEnrollment,
+        inProgressEnrollment,
+        notStartedEnrollment,
+      ]),
+    ).toBe(newestCompletedEnrollment);
+  });
+  it("should select the enrollment with the most recent start date if no completed dates", () => {
+    const newestInProgressEnrollment = createTestEnrollment({
+      start_date: new Date(new Date(baseDate).getTime() + 100000).toISOString(),
+      completion_date: null,
+      status: "Passed",
+    });
+    expect(
+      findMostRelevantEnrollment([
+        malformedEnrollment,
+        newestInProgressEnrollment,
+        inProgressEnrollment,
+        notStartedEnrollment,
+      ]),
+    ).toBe(newestInProgressEnrollment);
+  });
+  it("should select the enrollment with the most recent enrolled date if no completed, or started dates", () => {
+    const newestNotStartedEnrollment = createTestEnrollment({
+      enrollment_date: new Date(
+        new Date(baseDate).getTime() + 100000,
+      ).toISOString(),
+      start_date: null,
+      completion_date: null,
+      status: "Passed",
+    });
+    expect(
+      findMostRelevantEnrollment([
+        malformedEnrollment,
+        notStartedEnrollment,
+        newestNotStartedEnrollment,
+      ]),
+    ).toBe(newestNotStartedEnrollment);
+  });
+  it("should select the first enrollment if no enrollment, started, or completed dates", () => {
+    expect(findMostRelevantEnrollment([malformedEnrollment])).toBe(
+      malformedEnrollment,
+    );
+  });
+});

--- a/src/util/findMostRelevantEnrollment.ts
+++ b/src/util/findMostRelevantEnrollment.ts
@@ -1,0 +1,25 @@
+import maxBy from "lodash.maxby";
+import { TrainingEnrollment } from "../ProviderClient";
+
+/**
+ * A user can be enrolled in multiple instances of the same training module.
+ * Because the _key of the training module does not contain information from
+ * what campaign (nor should it) we need some way to connect the enrollment
+ * to the training module.
+ *
+ * What the user is expecting, is when a training module is completed, J1
+ * will update the relationship between training module and user with a
+ * completionDate, reguardless if there are other instances of that training
+ * in other campaigns that the user has not yet completed. In order to model
+ * it this way, we want to use only the most relevent enrollment when making
+ * these relationships.
+ */
+export function findMostRelevantEnrollment(
+  enrollments: TrainingEnrollment[],
+): TrainingEnrollment {
+  let e = maxBy(enrollments, "completion_date"); // The one most recently completed is the most relevant
+  e = e ? e : maxBy(enrollments, "start_date"); // Then the most recently started one
+  e = e ? e : maxBy(enrollments, "enrollment_date"); // Then the most recently enrolled one
+  e = e ? e : enrollments[0]; // Then just the first one (This should never happen)
+  return e;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,6 +954,20 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.groupby@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz#4d9b61a4d8b0d83d384975cabfed4c1769d6792e"
+  integrity sha512-kwg3T7Ia63KtDNoQQR8hKrLHCAgrH4I44l5uEMuA6JCbj7DiSccaV4tNV1vbjtAOpX990SolVthJCmBVtRVRgw==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.maxby@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.maxby/-/lodash.maxby-4.6.6.tgz#504b8d2d8e9366039dfe2b2b0bf77c64c433e3f1"
+  integrity sha512-bHlAUse1H1oi2D4AWwP04bJsofzWfXcEBr1Jin8/xSvI0Z/CGE2pcTgHg2oFm/pDXFtAOCDjurhaOynK6NYsZA==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.144"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.144.tgz#12e57fc99064bce45e5ab3c8bc4783feb75eab8e"
@@ -3488,6 +3502,16 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
+lodash.groupby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
+  integrity sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=
+
+lodash.maxby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.maxby/-/lodash.maxby-4.6.0.tgz#082240068f3c7a227aa00a8380e4f38cf0786e3d"
+  integrity sha1-CCJABo88eiJ6oAqDgOTzjPB4bj0=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
### Why

A user was seeing that when they completed a training in KnowBe4, a `completedBy` date was not being added to the ASSIGNED relationship between the user and the training module in JupiterOne. The actual issue is likely that there were two campaigns which contained the exact same training module the user just completed. As far as KnowBe4 was concerned, the user had completed the module in one campaign, but not in another.  Because we do not store campaign information in the _key of the training module, the persister was skipping the more relevant training enrollment (which was completed) because the _key was not unique. Example error:

```json
{
    "name": "jupiter-integration-knowbe4",
    "accountId": "j1dev",
    "actionName": "INGEST",
    "integrationInstanceId": "79ba9947-0439-4691-b849-4cf308c11914",
    "hostname": "169.254.174.197",
    "pid": 8,
    "awsRequestId": "155b9e27-0a6a-49eb-9515-115241536f95",
    "integrationJobId": "dcb651ab-96a2-4721-a61a-137872f5572e",
    "level": 30,
    "_key": "knowbe4:training:policy:22644_assigned_knowbe4:user:30047985",
    "differences": {
        "assignedOn": [
            1611583372000,
            1587660620000
        ],
        "startedOn": [
            null,
            1588088181000
        ],
        "completedOn": [
            null,
            1588088496000
        ],
        "status": [
            "Past Due",
            "Passed"
        ],
        "timeSpent": [
            0,
            141
        ]
    },
    "msg": "[SKIP] - Relationships in new dataset have identical key",
    "time": "2021-05-18T19:15:33.098Z",
    "v": 0
}

```

### Solution
Model training relationships in a way where if they have completed one instance of a training module, they get a Completed relationship to that module. As JupiterOne is concerned, if a user has completed any instance of the same training, they are good to go as far as Soc2 is concerned.

### Changes

- Only use most relevant enrollment when making relationships between training modules and users (the reason is explained in the documentation for filterDuplicateModules below)
- Remove campaign info from trainingModules as a single training module can be a part of multiple campaigns.
- Do not ingest retired training campaigns
